### PR TITLE
Adicionada validação de Bibtexkey

### DIFF
--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -1076,6 +1076,26 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
             putValue(Action.SHORT_DESCRIPTION, "Store field value");
         }
 
+        public boolean ehLetra(String s) {
+
+            char[] c = s.toCharArray();
+            boolean d = true;
+
+            if (!Character.isLetter(c[0])) {
+                d = false;
+            }
+            return d;
+        }
+
+        public boolean tamanhoValidoBibtexkey(String s) {
+            int tam = s.length();
+            if (tam <= 1) {
+                return false;
+            } else {
+                return true;
+            }
+        }
+
         @Override
         public void actionPerformed(ActionEvent event) {
             boolean movingAway = movingToDifferentEntry;
@@ -1097,7 +1117,8 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
 
                 // Make sure the key is legal:
                 String cleaned = LabelPatternUtil.checkLegalKey(newValue);
-                if ((cleaned == null) || cleaned.equals(newValue)) {
+                if (((cleaned == null) || cleaned.equals(newValue)) && tamanhoValidoBibtexkey(newValue)
+                        && ehLetra(newValue)) {
                     textField.setValidBackgroundColor();
                 } else {
                     JOptionPane.showMessageDialog(frame, Localization.lang("Invalid BibTeX key"),


### PR DESCRIPTION
Adicionada de acordo com o que foi pedido no trabalho a validação de uma BibTexKey. Não aceita keys que tenham como primeiro caracter algo diferente de uma letra e também não aceita keys que tenham menos que 1 caracter. Isso foi feito com a adição de duas funções na classe EntryEditor, entre as linhas 1079 e 1128.
Vejam se tem alguma alteração a ser feita.
